### PR TITLE
40-Fix reporter

### DIFF
--- a/pkg/unmixR/R/unittests.R
+++ b/pkg/unmixR/R/unittests.R
@@ -34,7 +34,7 @@ unmixR.unittest <- function () {
       lister$start_file(names (tests [t]))
       tests [[t]] ()
     }
-    get_reporter()$.end_context()
+    get_reporter()
   })
 
 

--- a/pkg/unmixR/R/unittests.R
+++ b/pkg/unmixR/R/unittests.R
@@ -1,9 +1,9 @@
 ##' Run the Unit Tests
 ##'
 ##' Run the unit tests for the package and output with the given testthat reporter.
-##' 
+##'
 ##  COMMENTED OUT @param reporter name of a testthat reporter. Defaults to \code{\link[testthat]{SummaryReporter}}.
-##' 
+##'
 ##' @return Invisibly returns a data frame with the test results
 ##'
 ##' @author Claudia Beleites
@@ -13,7 +13,7 @@
 ##' @export
 ##' @include unmixR-package.R
 ##' @importFrom testthat SummaryReporter ListReporter MultiReporter get_reporter
-##' 
+##'
 
 unmixR.unittest <- function () {
 
@@ -21,10 +21,10 @@ unmixR.unittest <- function () {
     warning("testthat required to run the unit tests.")
     return(NA)
   }
-  
+
   tests <- eapply(env = getNamespace ("unmixR"), FUN = get.test, all.names=TRUE)
   tests <- tests [! sapply (tests, is.null)]
-  
+
   reporter <- SummaryReporter$new()
   lister <- ListReporter$new()
   reporter <- MultiReporter$new(reporters = list(reporter, lister))


### PR DESCRIPTION
Removes the failure due to incorrect usage of the reporter. Related to #40, closes #45.

Note: this issue may have arisen due to changes in `testthat`.